### PR TITLE
Performance hotfix

### DIFF
--- a/digital_input.go
+++ b/digital_input.go
@@ -53,7 +53,10 @@ func (d *DigitalInputReader) Update(events chan *DigitalInputReader) (err error)
 }
 
 // Poll continuously updates the instance
-func (d *DigitalInputReader) Poll(events chan *DigitalInputReader, ticker *time.Ticker) {
+func (d *DigitalInputReader) Poll(events chan *DigitalInputReader, interval int) {
+	ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
+	defer ticker.Stop()
+
 	count := 0
 	for {
 		select {

--- a/digital_input_test.go
+++ b/digital_input_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 // setup for creating a temporary digital input
@@ -158,11 +157,6 @@ func TestPoll(t *testing.T) {
 	events := make(chan *DigitalInputReader)
 	defer close(events)
 
-	// Ticker
-	pollingInterval := 500 * time.Millisecond
-	ticker := time.NewTicker(pollingInterval)
-	defer ticker.Stop()
-
 	// Setup for triggering an event
 	digitalInput.Value = false
 	f.Seek(0, 0)
@@ -172,7 +166,7 @@ func TestPoll(t *testing.T) {
 	}
 
 	// Poll
-	go digitalInput.Poll(events, ticker)
+	go digitalInput.Poll(events, 500)
 
 	// Block on events
 	d := <-events
@@ -202,14 +196,9 @@ func TestPollError(t *testing.T) {
 	events := make(chan *DigitalInputReader)
 	defer close(events)
 
-	// Ticker
-	pollingInterval := 500 * time.Millisecond
-	ticker := time.NewTicker(pollingInterval)
-	defer ticker.Stop()
-
 	f.Close()
 	// Poll
-	go digitalInput.Poll(events, ticker)
+	go digitalInput.Poll(events, 500)
 
 	d := <-events
 

--- a/unipitt.go
+++ b/unipitt.go
@@ -2,7 +2,6 @@ package unipitt
 
 import (
 	"log"
-	"time"
 
 	"github.com/cenkalti/backoff"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -60,12 +59,10 @@ func (h *Handler) Poll(done chan bool, interval int, payload string) (err error)
 	events := make(chan *DigitalInputReader)
 	defer close(events)
 
-	ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
-
 	// Start polling
 	log.Printf("Initiate polling for %d readers\n", len(h.readers))
 	for k := range h.readers {
-		go h.readers[k].Poll(events, ticker)
+		go h.readers[k].Poll(events, interval)
 	}
 
 	// Publish on a trigger
@@ -82,7 +79,6 @@ func (h *Handler) Poll(done chan bool, interval int, payload string) (err error)
 			}
 		case <-done:
 			log.Println("Handler done polling, coming back ...")
-			ticker.Stop()
 			return
 		}
 	}


### PR DESCRIPTION
Rather than having a single timer for polling the individual readers,
have each them having their own ticker which is not exposed.